### PR TITLE
Change form action to relative link

### DIFF
--- a/src/main/resources/views/file.mustache
+++ b/src/main/resources/views/file.mustache
@@ -5,7 +5,7 @@
 </head>
 <body>
     <h1>Upload File with Dropwizard</h1>
-    <form action="http://localhost:8080/v1/files" method="post" enctype="multipart/form-data">
+    <form action="/v1/files" method="post" enctype="multipart/form-data">
        <p>
         Choose a file: <input type="file" name="file" />
        </p>


### PR DESCRIPTION
Because not everyone runs Dropwizard on port 8080 :-).
(Good example by the way)
